### PR TITLE
Adding case with proper path for Backdrop CMS

### DIFF
--- a/check_civicrm.php
+++ b/check_civicrm.php
@@ -38,6 +38,10 @@ switch (strtolower($argv[3])) {
     $path ='wp-content/plugins/civicrm/civicrm';
     break;
 
+  case 'backdrop':
+    $path ='modules/civicrm';
+    break;
+
   case 'drupal':
   default:
     $path = 'sites/all/modules/civicrm';


### PR DESCRIPTION
This commit adds a case with the path to use the check_civicrm with Backdrop CMS.
CiviCRM with Backdrop puts the php file at https://%URL%/modules/civicrm/extern/rest.php